### PR TITLE
.sto file reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: julia
+codecov: true
+
+## Documentation: http://docs.travis-ci.com/user/languages/julia/
+
+os:
+  - linux
+julia:
+  - 1
+  - 1.0
+  - nightly
+notifications:
+  email: false
+git:
+  depth: 99999999
+
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+jobs:
+  allow_failures:
+  - julia: nightly

--- a/Project.toml
+++ b/Project.toml
@@ -2,3 +2,11 @@ name = "SMPSReader"
 uuid = "702600ef-4881-4890-820b-5f0d39c8a3e9"
 authors = ["Mathieu Tanneau <mathieu.tanneau@gmail.com>"]
 version = "0.1.0"
+
+[deps]
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # SMPSReader.jl
 Julia reader for SMPS files
+
+Under construction.

--- a/src/SMPSReader.jl
+++ b/src/SMPSReader.jl
@@ -1,5 +1,5 @@
 module SMPSReader
 
-greet() = print("Hello World!")
+include("stoch.jl")
 
 end # module

--- a/src/stoch.jl
+++ b/src/stoch.jl
@@ -1,0 +1,183 @@
+"""
+    ScalarDiscrete
+
+Scalar random variable with discrete distribution.
+"""
+mutable struct ScalarDiscrete
+    vals::Vector{Float64}
+    probs::Vector{Float64}
+end
+
+"""
+    ScalarUniform(l::Float64, u::Float64)
+
+Scalar random variable with uniform distribution ``\\mathcal{U}[l, u]``
+
+Both `l` and `u` must be finite.
+"""
+struct ScalarUniform
+    l::Float64
+    u::Float64
+end
+
+
+"""
+    ScalarNormal(μ::Float64, σ2::Float64)
+
+Scalar random variable with distribution ``\\mathcal{N}(\\mu, \\sigma^{2})``.
+
+`μ` must be finite and `σ2` must be non-negative.
+"""
+struct ScalarNormal
+    μ::Float64  # mean
+    σ2::Float64  # variance
+end
+
+const RandomVariable = Union{ScalarDiscrete, ScalarUniform, ScalarNormal}
+
+
+mutable struct BlockDiscrete
+    # by convention, the first block is the reference block
+    blocks::Vector{Vector{Tuple{String, String, Float64}}}
+    probs::Vector{Float64}
+end
+
+const RandomVector = Union{BlockDiscrete}
+
+const RandomVarOrVec = Union{RandomVariable, RandomVector}
+
+mutable struct StocData
+    name::String  # Problem name
+
+    indeps::Dict{Union{String, Tuple{String, String}}, RandomVarOrVec}
+
+    StocData() = new("", Dict{Union{String, Tuple{String, String}}, RandomVarOrVec}())
+end
+
+import Base.read!
+
+function Base.read!(io::IO, dat::StocData)
+
+    # Current section
+    section = ""
+
+    # Type of distribution
+    dist = ""
+
+    # Name of current block.
+    # Will be used when parsing blocks
+    current_block = ""
+
+    while !eof(io)
+        ln = readline(io)
+
+        # Skip empty lines
+        (length(ln) == 0) && continue
+
+        # Check for section header
+        if ln[1] != ' '
+            fields = String.(split(ln))
+
+            section = fields[1]
+
+            if section == "STOCH"
+                # Read problem name
+                dat.name = fields[2]
+
+            elseif section == "INDEP" || section == "BLOCKS"
+                # Read type of distribution
+                dist = fields[2]
+
+            elseif section == "ENDATA"
+                # stop
+                break
+            else
+                # Unknown section
+                error("Unknown section header: $section")
+            end
+
+            continue
+        end
+
+        # Parse line
+        if section == "INDEP"
+            fields = String.(split(ln))
+            col, row, v1, v2 = fields[1], fields[2], parse(Float64, fields[3]), parse(Float64, fields[5])
+
+            if dist == "DISCRETE"
+                if haskey(dat.indeps, (row, col))
+                    # Update existing distribution
+                    d = dat.indeps[row, col]  # /!\ type unstable
+                    push!(d.vals, v1)
+                    push!(d.probs, v2)
+                else
+                    # Create new random variable
+                    dat.indeps[row, col] = ScalarDiscrete([v1], [v2])
+                end
+            
+            elseif dist == "UNIFORM"
+                haskey(dat.indeps, (row, col)) && error("Existing entry for pair ($row, $col)")
+                dat.indeps[row, col] = ScalarUniform(v1, v2)
+
+            elseif dist == "NORMAL"
+                haskey(dat.indeps, (row, col)) && error("Existing entry for pair ($row, $col)")
+                dat.indeps[row, col] = ScalarNormal(v1, v2)
+            else
+                error("Distribution $dist is not yet supported. Please file an issue")
+            end
+
+        elseif section == "BLOCKS"
+            fields = String.(split(ln))
+
+            if dist == "DISCRETE"
+
+                if fields[1] == "BL"
+                    # new block entry
+                    # Record block name and its probability
+                    current_block = fields[2]
+                    prob = parse(Float64, fields[4])
+
+                    # Check if block already exists
+                    if haskey(dat.indeps, current_block)
+                        block = dat.indeps[current_block]  # /!\ type unstable
+
+                        # Create new entry
+                        push!(block.probs, prob)
+                        push!(block.blocks, Tuple{String, String, String}[])
+                    else
+                        # Create new block
+                        block = BlockDiscrete([Tuple{String, String, String}[]], [prob])
+                        dat.indeps[current_block] = block
+                    end
+                else
+                    # TODO: this would be more efficient if we just kept a pointer
+                    # to the block object itself
+                    block = dat.indeps[current_block]
+
+                    # parse line
+                    col, row1, val1 = fields[1], fields[2], parse(Float64, fields[3])
+
+                    # Add entry
+                    push!(block.blocks[end], (col, row1, val1))
+                    
+                    if length(fields) >= 5
+                        # parse the second entry
+                        row2, val2 = fields[4], parse(Float64, fields[5])
+                        # Add entry to block
+                        push!(block.blocks[end], (col, row2, val2))
+                    end
+
+                end
+
+            else
+                error("Distribution $dist is not yet supported. Please file an issue")
+            end
+
+        end
+
+    end
+
+    section == "ENDATA" || error("File ended before reaching ENDATA")
+
+    return dat
+end

--- a/src/stoch.jl
+++ b/src/stoch.jl
@@ -158,13 +158,13 @@ function Base.read!(io::IO, dat::StocData)
                     col, row1, val1 = fields[1], fields[2], parse(Float64, fields[3])
 
                     # Add entry
-                    push!(block.blocks[end], (col, row1, val1))
+                    push!(block.blocks[end], (row1, col, val1))
                     
                     if length(fields) >= 5
                         # parse the second entry
                         row2, val2 = fields[4], parse(Float64, fields[5])
                         # Add entry to block
-                        push!(block.blocks[end], (col, row2, val2))
+                        push!(block.blocks[end], (row2, col, val2))
                     end
 
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,3 @@
+using Test
+
+include("stoch.jl")

--- a/test/stoch.jl
+++ b/test/stoch.jl
@@ -1,0 +1,23 @@
+using SMPSReader
+const SMPS = SMPSReader
+
+DAT_DIR = joinpath(@__DIR__, "../dat")
+
+
+function test_indep_discrete()
+    sdat = SMPS.StocData()
+
+    open("test1.sto") do fsto
+        read!(fsto, sdat)
+    end
+
+    @test sdat.name == "TEST1"
+
+    @test length(sdat.indeps) == 2
+end
+
+@testset ".sto reader" begin
+    @testset "INDEP - DISCRETE" begin
+        test_indep_discrete()
+    end
+end

--- a/test/stoch.jl
+++ b/test/stoch.jl
@@ -14,10 +14,70 @@ function test_indep_discrete()
     @test sdat.name == "TEST1"
 
     @test length(sdat.indeps) == 2
+    @test haskey(sdat.indeps, ("R000001", "X0001"))
+    @test haskey(sdat.indeps, ("R000002", "X0002"))
+
+    # check problem data
+    d1 = sdat.indeps["R000001", "X0001"]
+    @test all(d1.vals  .== [6.0, 8.0])
+    @test all(d1.probs .== [0.5, 0.5])
+
+    d2 = sdat.indeps["R000002", "X0002"]
+    @test all(d2.vals  .== [1.0, 2.0, 3.0])
+    @test all(d2.probs .== [0.1, 0.5, 0.4])
+
+end
+
+function test_blocks_discrete()
+    sdat = SMPS.StocData()
+
+    open("test2.sto") do fsto
+        read!(fsto, sdat)
+    end
+
+    @test sdat.name == "TEST2"
+
+    @test length(sdat.indeps) == 2  # two different blocks
+    @test haskey(sdat.indeps, "BLOCK1")
+    @test haskey(sdat.indeps, "BLOCK2")
+
+    # Check that each block was read properly
+    b1 = sdat.indeps["BLOCK1"]
+    @test all(b1.probs .== [0.6, 0.4])
+    @test all(b1.blocks[1] .== [
+        ("C000001", "X0001", 1.1), ("C000002", "X0001", 1.2),
+        ("C000001", "X0002", 2.1), ("C000002", "X0002", 2.2),
+        ("C000001", "X0003", 3.1), ("C000002", "X0003", 3.2)
+    ])
+    @test all(b1.blocks[2] .== [
+        ("C000001", "X0001", 11.1), ("C000002", "X0001", 11.2),
+        ("C000001", "X0002", 12.1), ("C000002", "X0002", 12.2)
+    ])
+
+    b2 = sdat.indeps["BLOCK2"]
+    @test all(b2.probs .== [0.25, 0.35, 0.40])
+    @test all(b2.blocks[1] .== [
+        ("C000001", "RIGHT", 1.0), ("C000002", "RIGHT", 2.0),
+        ("C000003", "RIGHT", 3.0), ("C000004", "RIGHT", 4.0)
+    ])
+    @test all(b2.blocks[2] .== [
+        ("C000001", "RIGHT", 1.1), ("C000002", "RIGHT", 2.1),
+        ("C000003", "RIGHT", 3.1)
+    ])
+    @test all(b2.blocks[3] .== [
+        ("C000001", "RIGHT", 1.2), ("C000002", "RIGHT", 2.2),
+        ("C000003", "RIGHT", 3.2)
+    ])
+
+
 end
 
 @testset ".sto reader" begin
     @testset "INDEP - DISCRETE" begin
         test_indep_discrete()
+    end
+
+    @testset "BLOCKS - DISCRETE" begin
+        test_blocks_discrete()
     end
 end

--- a/test/test1.sto
+++ b/test/test1.sto
@@ -1,0 +1,8 @@
+STOCH         TEST1    
+INDEP         DISCRETE
+    X0001     R000001     6.0          PERIOD2   0.5
+    X0001     R000001     8.0          PERIOD2   0.5
+    X0002     R000002     1.0          PERIOD2   0.1
+    X0002     R000002     2.0          PERIOD2   0.5
+    X0002     R000002     3.0          PERIOD2   0.4
+ENDATA

--- a/test/test2.sto
+++ b/test/test2.sto
@@ -1,0 +1,21 @@
+STOCH         TEST2    
+BLOCKS        DISCRETE
+ BL BLOCK1    PERIOD2     0.60
+    X0001     C000001     1.1          C000002   1.2
+    X0002     C000001     2.1          C000002   2.2
+    X0003     C000001     3.1          C000002   3.2
+ BL BLOCK1    PERIOD2     0.40
+    X0001     C000001     11.1         C000002   11.2
+    X0002     C000001     12.1         C000002   12.2
+ BL BLOCK2    PERIOD2     0.25
+    RIGHT     C000001     1.0          C000002   2.0
+    RIGHT     C000003     3.0          C000004   4.0
+ BL BLOCK2    PERIOD2     0.35
+    RIGHT     C000001     1.1
+    RIGHT     C000002     2.1
+    RIGHT     C000003     3.1
+ BL BLOCK2    PERIOD2     0.40
+    RIGHT     C000001     1.2
+    RIGHT     C000002     2.2
+    RIGHT     C000003     3.2
+ENDATA


### PR DESCRIPTION
Data structures and parser for `.sto` files.

The random variables/vectors' distributions are stored in a lazy fashion, i.e., we only store the differences with respect to the "reference" values (those given in the `.cor` file).
Doing so is 1) easier and 2) lighter on memory.

We can add a function later for creating the deterministic equivalent problem.

Currently, only the following distributions are supported:
* `INDEP`
  * `DISCRETE`
  * `UNIFORM`
  * `NORMAL`
* `BLOCKS`
  * `DISCRETE`

Other distributions, such as `SCENARIOS` and linear transformations (keyword `LINTR`) are not supported yet.